### PR TITLE
renamed package to faucet-pipeline-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# faucet-pipeline
-[![npm](https://img.shields.io/npm/v/faucet-pipeline.svg)](https://www.npmjs.com/package/faucet-pipeline)
-[![Build Status](https://travis-ci.org/faucet-pipeline/faucet-pipeline.svg?branch=master)](https://travis-ci.org/faucet-pipeline/faucet-pipeline)
-[![Greenkeeper badge](https://badges.greenkeeper.io/faucet-pipeline/faucet-pipeline.svg)](https://greenkeeper.io)
+faucet-pipeline-core
+====================
+
+[![npm](https://img.shields.io/npm/v/faucet-pipeline-core.svg)](https://www.npmjs.com/package/faucet-pipeline-core)
+[![build status](https://travis-ci.org/faucet-pipeline/faucet-pipeline-core.svg?branch=master)](https://travis-ci.org/faucet-pipeline/faucet-pipeline-core)
+[![Greenkeeper badge](https://badges.greenkeeper.io/faucet-pipeline/faucet-pipeline-core.svg)](https://greenkeeper.io)
 
 You can find the documentation [here](http://www.faucet-pipeline.org).
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,11 +53,8 @@ function makeWatcher(watchDirs, referenceDir, resolvePath) {
 	watcher.on("error", err => {
 		if(err.code === "ERR_TOO_MANY_FILES") {
 			abort("ERROR: there are too many files being monitored - please " +
-					"use the `watchDirs` configuration setting:\n" +
-					// eslint-disable-next-line max-len
-					"https://github.com/faucet-pipeline/faucet-pipeline#configuration-for-file-watching");
+					"use the `watchDirs` configuration setting");
 		}
-
 		throw err;
 	});
 	return watcher;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "faucet-pipeline",
+	"name": "faucet-pipeline-core",
 	"version": "1.0.0-rc.7",
 	"description": "front-end asset pipeline",
 	"author": "FND",
@@ -7,13 +7,13 @@
 		"Lucas Dohmen <lucas.dohmen@innoq.com>"
 	],
 	"license": "Apache-2.0",
-	"homepage": "https://github.com/faucet-pipeline/faucet-pipeline",
+	"homepage": "https://github.com/faucet-pipeline/faucet-pipeline-core",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/faucet-pipeline/faucet-pipeline.git"
+		"url": "https://github.com/faucet-pipeline/faucet-pipeline-core.git"
 	},
 	"bugs": {
-		"url": "https://github.com/faucet-pipeline/faucet-pipeline/issues"
+		"url": "https://github.com/faucet-pipeline/faucet-pipeline-core/issues"
 	},
 	"main": "lib/index.js",
 	"bin": {


### PR DESCRIPTION
as discussed elsewhere, end users are encouraged to install individual plugins instead, which in turn depend on faucet-core - thus having a faucet-pipeline package is misleading

* [x] rename repository
* [x] deprecate faucet-pipeline package - this might also `throw` to really make sure users aren't tempted to mistakenly install that wretched package

    ```
    $ npm deprecate faucet-pipeline "the faucet-pipeline package has been renamed to faucet-pipeline-core - this is merely a low-level dependency; please install your preferred plugin(s) directly"
    ```

    I concluded that `throw`ing wasn't sensible, for now anyway

* [x] publish faucet-pipeline-core package
* [ ] update CI (Travis, Greenkeeper)
* [ ] update faucet-js
* [ ] update faucet-sass
* [ ] update faucet-static
* [ ] update faucet-images