### PR TITLE
Add higher timeouts for reading from the manifest

### DIFF
--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -4,7 +4,7 @@ let path = require("path");
 let createFile = require("./util/files");
 let { abort, repr } = require("./util");
 
-let retryTimings = [10, 50, 100, 250, 500, 1000];
+let retryTimings = [10, 50, 100, 250, 500, 1000, 2000, 4000];
 
 module.exports = class Manifest {
 	constructor(filepath, { key, value, baseURI, webRoot }, resolvePath) {


### PR DESCRIPTION
I updated Fejo to the latest version of all packages. This leads to failing the build every fourth or fifth time. The reason for that: A file handled by the static pipeline has not yet been added to the manifest. I think this has to be addressed in a more general way... But for now, I want to have a quick fix. And that means: Increasing the timeout.