### PR TITLE
Introduce Build Steps

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,11 +5,24 @@ let { abort, repr } = require("./util");
 let browserslist = require("browserslist");
 
 let DEFAULTS = {
-	plugins: { // maps config identifiers to corresponding import identifiers
-		js: "faucet-pipeline-js",
-		sass: "faucet-pipeline-sass",
-		static: "faucet-pipeline-static",
-		images: "faucet-pipeline-images"
+	// maps config identifiers to corresponding import identifiers and buckets
+	plugins: {
+		js: {
+			plugin: "faucet-pipeline-js",
+			bucket: "scripts"
+		},
+		sass: {
+			plugin: "faucet-pipeline-sass",
+			bucket: "styles"
+		},
+		static: {
+			plugin: "faucet-pipeline-static",
+			bucket: "static"
+		},
+		images: {
+			plugin: "faucet-pipeline-images",
+			bucket: "static"
+		}
 	}
 };
 
@@ -19,24 +32,47 @@ module.exports = (referenceDir, config, { watch, fingerprint, sourcemaps, compac
 		fingerprint,
 		exitOnError: !watch
 	});
-	let watcher = watch && makeWatcher(config.watchDirs, referenceDir,
-			assetManager.resolvePath);
 	let browsers = browserslist.findConfig(referenceDir) || {};
 
 	let plugins = Object.assign({}, DEFAULTS.plugins, config.plugins);
+	let buckets = {
+		static: [],
+		scripts: [],
+		styles: [],
+		markup: []
+	};
 	Object.keys(plugins).forEach(type => {
 		let pluginConfig = config[type];
 		if(!pluginConfig) {
 			return;
 		}
 
-		let plugin = plugins[type];
+		let { bucket, plugin } = plugins[type];
 		if(!plugin.call) {
 			plugin = load(plugin);
 		}
-		plugin(pluginConfig, assetManager, { watcher, browsers, sourcemaps, compact });
+		let build = plugin(pluginConfig, assetManager,
+				{ browsers, sourcemaps, compact });
+		buckets[bucket].push(build);
 	});
+
+	let buildAll = files => {
+		return buildStep(buckets.static)(files).
+			then(buildStep(buckets.scripts.concat(buckets.styles))).
+			then(buildStep(buckets.markup));
+	};
+	buildAll();
+
+	if(watch) {
+		makeWatcher(config.watchDirs, referenceDir, assetManager.resolvePath).
+			on("edit", buildAll);
+	}
 };
+
+function buildStep(plugins) {
+	return files => Promise.all(plugins.map(plugin => plugin(files))).
+		then(() => files);
+}
 
 function makeWatcher(watchDirs, referenceDir, resolvePath) {
 	let niteOwl = require("nite-owl");

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 let AssetManager = require("./manager");
 let { abort, repr } = require("./util");
 let browserslist = require("browserslist");
+let SerializedRunner = require("./util/runner");
 
 let DEFAULTS = {
 	// maps config identifiers to corresponding import identifiers and buckets
@@ -52,16 +53,18 @@ module.exports = (referenceDir, config, { watch, fingerprint, sourcemaps, compac
 		buckets[bucket].push(build);
 	});
 
-	let buildAll = files => {
+	let runner = new SerializedRunner(files => {
 		return buildStep(buckets.static)(files).
 			then(buildStep(buckets.scripts.concat(buckets.styles))).
 			then(buildStep(buckets.markup));
-	};
-	buildAll();
+	});
+	runner.run();
 
 	if(watch) {
 		makeWatcher(config.watchDirs, referenceDir, assetManager.resolvePath).
-			on("edit", buildAll);
+			on("edit", filepaths => {
+				runner.rerun(filepaths);
+			});
 	}
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,10 +18,6 @@ let DEFAULTS = {
 		static: {
 			plugin: "faucet-pipeline-static",
 			bucket: "static"
-		},
-		images: {
-			plugin: "faucet-pipeline-images",
-			bucket: "static"
 		}
 	}
 };

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -2,9 +2,7 @@
 
 let path = require("path");
 let createFile = require("./util/files");
-let { abort, repr } = require("./util");
-
-let retryTimings = [10, 50, 100, 250, 500, 1000, 2000, 4000];
+let { abort } = require("./util");
 
 module.exports = class Manifest {
 	constructor(filepath, { key, value, baseURI, webRoot }, resolvePath) {
@@ -27,24 +25,6 @@ module.exports = class Manifest {
 			webRoot = resolvePath(webRoot || "./", { enforceRelative: true });
 			this.valueTransform = filepath => baseURI + path.relative(webRoot, filepath);
 		}
-
-		this._resolve = this._resolve.bind(this);
-	}
-
-	// repeatedly attempts `#get` until it resolves successfully or times out
-	resolve(originalPath) {
-		return retry(this._resolve, retryTimings)(originalPath);
-	}
-
-	_resolve(originalPath) {
-		return new Promise((resolve, reject) => {
-			let actualPath = this.get(originalPath);
-			if(actualPath) {
-				resolve(actualPath);
-			} else {
-				reject(new Error(`could not find asset ${repr(originalPath)}`));
-			}
-		});
 	}
 
 	get(originalPath) {
@@ -64,24 +44,3 @@ module.exports = class Manifest {
 		return JSON.stringify(this._index) + "\n";
 	}
 };
-
-// repeatedly invokes a function which returns a promise until it is resolved or
-// all `retries` are exhausted
-// `retries` is an array of milliseconds to wait in between attempts
-// returns a new function that wraps `fn`, accepting the same arguments
-function retry(fn, retries) {
-	return (...params) => fn(...params).
-		catch(err => {
-			if(retries.length === 0) {
-				throw err;
-			}
-
-			let backoff = retries.shift();
-			return wait(backoff).
-				then(_ => retry(fn, retries)(...params));
-		});
-}
-
-function wait(ms) {
-	return new Promise(resolve => setTimeout(resolve, ms));
-}


### PR DESCRIPTION
**This is a breaking change to the contract between the plugins and faucet-pipeline-core**

Plugins now consist of a package and a bucket. The package is either a function or the name of a package that should be loaded. In either case, the function or loaded package need to adhere to the contract described below. The bucket is either static, scripts, styles or markup. This determines the type of output the plugin creates. This PR also removes the resolve function for looking up things in the manifest with a retry as this is no longer needed.

## Contract

A plugin is a function that takes:

* pluginConfig: The configuration the user provided for this plugin
* assetManager: An object that provides the functionality to write files and access the manifest
* { browsers, sourcemaps, compact }: Additional information on what kind of output should be created

The function returns a function that:

* Takes either undefined or an array of file paths. If undefined is passed, it should build everything. If an array of file paths is passed, it should just build things that change due to changes in those files.
* It returns a promise. The promise resolves when all work is done.

## Build Steps

The plugins are run in the following order for the first run and all file changes in watch mode:

* Step 1: All plugins with bucket static
* Step 1: All plugins with bucket styles or scripts
* Step 1: All plugins with bucket markup

## Additional changes

* The support for faucet-pipeline-images was removed, as it will be merged into faucet-pipeline-static.
* The pipeline is now run in a serialized runner. Pipelines therefore do not need to take care of that.