### PR TITLE
Bugfix: Watching was broken

### DIFF
--- a/lib/util/runner.js
+++ b/lib/util/runner.js
@@ -5,9 +5,9 @@ module.exports = class SerializedRunner {
 		this.asyncOp = asyncOp;
 	}
 
-	run() {
+	run(...args) {
 		if(!this._pending) { // prevent concurrent execution
-			this._pending = augment(this.asyncOp()).
+			this._pending = augment(this.asyncOp(...args)).
 				finally(_ => {
 					this._pending = null;
 				});
@@ -16,13 +16,13 @@ module.exports = class SerializedRunner {
 	}
 
 	// repeats execution exactly once after waiting for any pending execution to conclude
-	rerun() {
+	rerun(...args) {
 		if(this._queued) { // limit queue to a single repeat execution
 			return this._queued;
 		}
 
 		let enqueue = this._pending;
-		let res = this.run();
+		let res = this.run(...args);
 		if(enqueue) {
 			this._queued = res = augment(res).
 				finally(_ => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "faucet-pipeline-core",
-	"version": "1.0.0-rc.11",
+	"version": "1.0.0-rc.12",
 	"description": "front-end asset pipeline",
 	"author": "FND",
 	"contributors": [


### PR DESCRIPTION
Even though runner.rerun was called with arguments, those arguments were not passed to the wrapped function. Therefore it didn't work when watching: The functions were called without the filepaths of the files that changed.