### PR TITLE
Manifest without a file

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -19,11 +19,6 @@ module.exports = class AssetManager {
 		if(manifestConfig) {
 			let { resolvePath } = this;
 
-			if(manifestConfig.file) { // deprecated
-				abort("ERROR: `manifest.file` has been renamed to " +
-						"`manifest.target` - please adjust your configuration");
-			}
-
 			let manifestPath = resolvePath(manifestConfig.target, {
 				enforceRelative: true
 			});

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -16,9 +16,7 @@ module.exports = class AssetManager {
 		this.writeFile = this.writeFile.bind(this);
 		this.resolvePath = this.resolvePath.bind(this);
 
-		if(manifestConfig) {
-			this.manifest = new Manifest(manifestConfig, this.resolvePath);
-		}
+		this.manifest = new Manifest(manifestConfig || {}, this.resolvePath);
 	}
 
 	// NB: `fingerprint` option takes precedence over corresponding instance property

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -17,12 +17,7 @@ module.exports = class AssetManager {
 		this.resolvePath = this.resolvePath.bind(this);
 
 		if(manifestConfig) {
-			let { resolvePath } = this;
-
-			let manifestPath = resolvePath(manifestConfig.target, {
-				enforceRelative: true
-			});
-			this.manifest = new Manifest(manifestPath, manifestConfig, resolvePath);
+			this.manifest = new Manifest(manifestConfig, this.resolvePath);
 		}
 	}
 

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -5,8 +5,12 @@ let createFile = require("./util/files");
 let { abort } = require("./util");
 
 module.exports = class Manifest {
-	constructor(filepath, { key, value, baseURI, webRoot }, resolvePath) {
-		this.filepath = filepath;
+	constructor({ target, key, value, baseURI, webRoot }, resolvePath) {
+		if(target) {
+			this.filepath = resolvePath(target, {
+				enforceRelative: true
+			});
+		}
 		this._index = {};
 
 		if(key === "short") {


### PR DESCRIPTION
This is a bug found by @joyheron. With this PR:

* Remove an old deprecation warning.
* Make it optional to provide a `target` for a manifest (it threw a weird error before). If you don't provide a target, the manifest will not be written to disk. There will only be the in-memory manifest.
* Don't require users to write `manifest` in their faucet.config. You only need this if you want to write the manifest to disk or want to change the key or value.