### PR TITLE
ensured parent paths are considered relative

### DIFF
--- a/lib/util/resolve.js
+++ b/lib/util/resolve.js
@@ -14,7 +14,7 @@ if(!legacy) { // account for bug in Node v8.9.4 and below
 }
 
 module.exports = function resolvePath(filepath, referenceDir, { enforceRelative } = {}) {
-	if(filepath.substr(0, 2) === "./") {
+	if(/^\.?\.\//.test(filepath)) { // starts with `./` or `../`
 		return path.resolve(referenceDir, filepath);
 	} else if(enforceRelative) {
 		abort(`ERROR: path must be relative: ${repr(filepath)}`);


### PR DESCRIPTION
> technically this is a breaking change, but it doesn't seem likely that
> anyone is currently relying on the previous restriction to descendants
> of the reference directory

¯\\\_(ツ)_/¯