### PR TITLE
Use minimist features

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -25,6 +25,10 @@ Options:
 
 module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {
 	argv = parseArgs(argv, {
+		boolean: ["watch", "fingerprint", "sourcemaps", "compact"],
+		default: {
+			config: "faucet.config.js"
+		},
 		alias: {
 			c: "config",
 			w: "watch",
@@ -36,14 +40,12 @@ module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {
 		abort(help, 0);
 	}
 
-	let options = ["watch", "fingerprint", "sourcemaps", "compact"];
-	options = options.reduce((memo, option) => {
-		let value = argv[option];
-		if(value !== undefined) {
-			memo[option] = value;
-		}
-		return memo;
-	}, {});
+	let options = {
+		watch: argv.watch,
+		fingerprint: argv.fingerprint,
+		sourcemaps: argv.sourcemaps,
+		compact: argv.compact
+	};
 
 	if(options.watch && options.fingerprint) { // for convenience
 		console.error("you might consider disabling fingerprinting in watch " +


### PR DESCRIPTION
This makes more use of the features provided by minimist. What I like about it: The arguments to `parseArgs` now mirror the `-h` text above. What @FND probably dislikes about it: It makes the four options Booleans, instead of Maybe(Boolean)s.