### PR TITLE
35c3 PR

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -21,6 +21,10 @@ Options:
     generate source maps (where supported)
   --compact
     reduce output size (where supported)
+  --serve [HOST:]PORT
+    serve the files via HTTP
+  --liveserve [HOST:]PORT
+    serve the files via HTTP with live reload
 `.trim();
 
 module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {
@@ -41,7 +45,9 @@ module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {
 		watch: argv.watch,
 		fingerprint: argv.fingerprint,
 		sourcemaps: argv.sourcemaps,
-		compact: argv.compact
+		compact: argv.compact,
+		serve: argv.serve,
+		liveserve: argv.liveserve
 	};
 
 	if(options.watch && options.fingerprint) { // for convenience

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ let resolvePath = require("./util/resolve");
 let { loadExtension, abort, repr } = require("./util");
 let browserslist = require("browserslist");
 let SerializedRunner = require("./util/runner");
+let server = require("./server");
 
 let DEFAULTS = {
 	// maps config identifiers to corresponding import identifiers and buckets
@@ -24,7 +25,7 @@ let DEFAULTS = {
 	}
 };
 
-module.exports = (referenceDir, config, { watch, fingerprint, sourcemaps, compact }) => {
+module.exports = (referenceDir, config, { watch, fingerprint, sourcemaps, compact, serve, liveserve }) => {
 	let assetManager = new AssetManager(referenceDir, {
 		manifestConfig: config.manifest,
 		fingerprint,
@@ -66,6 +67,16 @@ module.exports = (referenceDir, config, { watch, fingerprint, sourcemaps, compac
 			on("edit", filepaths => {
 				runner.rerun(filepaths);
 			});
+	}
+
+	if(serve && liveserve) {
+		abort("ERROR: You can't use serve and liveserve at once");
+	}
+	if(serve) {
+		server.static(serve, assetManager.manifest.webRoot);
+	}
+	if(liveserve) {
+		server.live(liveserve, assetManager.manifest.webRoot);
 	}
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,10 @@ let DEFAULTS = {
 		static: {
 			plugin: "faucet-pipeline-static",
 			bucket: "static"
+		},
+		nunjucks: {
+			plugin: "faucet-pipeline-nunjucks",
+			bucket: "markup"
 		}
 	}
 };

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -20,6 +20,9 @@ module.exports = class Manifest {
 			this.keyTransform = key || (filepath => filepath);
 		}
 
+		this.webRoot = resolvePath(webRoot || "./", referenceDir,
+				{ enforceRelative: true });
+
 		if(value) {
 			if(baseURI || webRoot) {
 				abort("ERROR: `value` cannot be used with `baseURI` and/or `webRoot`");
@@ -27,9 +30,7 @@ module.exports = class Manifest {
 			this.valueTransform = value;
 		} else {
 			baseURI = baseURI || "/";
-			webRoot = resolvePath(webRoot || "./", referenceDir,
-					{ enforceRelative: true });
-			this.valueTransform = filepath => baseURI + path.relative(webRoot, filepath);
+			this.valueTransform = filepath => baseURI + path.relative(this.webRoot, filepath);
 		}
 	}
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,0 +1,40 @@
+let { loadExtension } = require("./util");
+
+exports.static = function(config, webroot) {
+	let donny = loadExtension("donny",
+			"you need to install donny to use --serve");
+	let [bind, port] = parse(config);
+
+	donny({
+		port,
+		bind,
+		webroot
+	}).then(() => {
+		console.error(`Serving '${webroot}' on port ${port}`);
+	});
+};
+
+exports.live = function(config, root) {
+	let liveServer = loadExtension("live-server",
+			"you need to install live-server to use --liveserve");
+	let [host, port] = parse(config);
+
+	liveServer.start({
+		port,
+		host,
+		root,
+		open: false
+	});
+};
+
+let format = /([\d.]+:)?(\d+)/;
+function parse(config) {
+	// eslint-disable-next-line no-unused-vars
+	let [_, host, port] = format.exec(config);
+	host = host || "0.0.0.0:";
+
+	return [
+		host.slice(0, -1),
+		port
+	];
+}


### PR DESCRIPTION
During 35c3, I did some hacking on faucet. This is the result:

1. expose the webRoot in the manifest (preperatory refactoring): The manifest object now saves its webRoot in an instance variable so it can be accessed from the outside.
2. allow users to serve their files via HTTP for development. Users have two options: If they only want to serve, they can use [donny](https://www.npmjs.com/package/donny) – a small static file server with (almost) no dependencies. If they want live reload, they need [live-server](https://github.com/tapio/live-server). Both are optional dependencies that the users need to install themselves. This new functionality is useful when you use faucet as a static site generator ([faucet-pipeline-nunjucks](https://github.com/faucet-pipeline/faucet-pipeline-nunjucks/) for example) or for projects like [aiur](https://github.com/moonglum/aiur/)
3. add support for the new [faucet-pipeline-nunjucks](https://github.com/faucet-pipeline/faucet-pipeline-nunjucks) 