### PR TITLE
dropped support for Node v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-- 6
 - 8
 - 10
 

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -2,8 +2,10 @@
 
 let path = require("path");
 let crypto = require("crypto");
+let { promisify } = require("util");
 
 exports.abort = abort;
+exports.promisify = promisify; // deprecated
 exports.repr = repr;
 
 // reports success or failure for a given file path (typically regarding
@@ -32,20 +34,6 @@ exports.generateFingerprint = (filepath, data) => {
 	let name = ext.length === 0 ? filename : path.basename(filepath, ext);
 	let hash = generateHash(data);
 	return path.join(path.dirname(filepath), `${name}-${hash}${ext}`);
-};
-
-// simplistic imitation of Node 8's `util.promisify`
-// NB: only supports a single callback parameter
-exports.promisify = fn => {
-	return (...args) => new Promise((resolve, reject) => {
-		fn(...args, (err, res) => {
-			if(err) {
-				reject(err);
-				return;
-			}
-			resolve(res);
-		});
-	});
 };
 
 function abort(msg, code = 1) {


### PR DESCRIPTION
> April 2019 marks the end of life for this LTS version, so it should soon
> be phased out by users
>
> retaining `promisify` for now to avoid breaking changes (even though
> downstream libraries would only need to change the respective import
> path - assuming our implementation is in fact compatible with Node's)

see #49