### PR TITLE
v1.3.0 (re-release due to violation of semantic versioning)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+- 8.9.3
 - 8
 - 10
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
 - 8.9.3
 - 8
-- 10
+- 12
 
 script:
 - npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,32 +1,27 @@
 faucet-pipeline-core version history
 ====================================
 
-v1.2.2
+
+v1.3.0
 ------
 
-_2019-06-17_
+_2019-09-02_
 
-changes for end users:
+(this version was erroneously released as v1.2.x before, violating semantic
+versioning)
 
-* update browserslist
-
-v1.2.1
-------
-
-_2019-05-02_
-
-changes for end users:
+notable changes for end users:
 
 * dropped support for Node 6
-* improve handling of boolean CLI arguments
-* update browserslist and nite-owl
-* offer a `--serve` and `--liveserve` CLI option to serve the generated files
+* path resolution now expects non-relative paths (e.g. `my-lib/util.js`) to
+  reside within `node_modules`
+* added `--serve` and `--liveserve` CLI options to serve the generated files
   via HTTP
+* improved handling of boolean CLI arguments
 
-improvements for developers:
+notable changes for developers:
 
-* update mocha
-* expose the `webRoot` in the manifest
+* exposed `webRoot` in `Manifest`
 
 
 v1.2.0
@@ -34,14 +29,14 @@ v1.2.0
 
 _2018-11-29_
 
-improvements for end users:
+notable changes for end users:
 
 * ensured parent paths (i.e. `../`) are permitted where configuration expects
   relative paths
 * ensured consistent manifest representation, avoiding changes due to arbitrary
   ordering
 
-improvements for developers:
+notable changes for developers:
 
 * added `loadExtension` utility function to prompt for installation of missing
   packages
@@ -54,10 +49,10 @@ v1.1.0
 
 _2018-10-23_
 
-improvements for end users:
+notable changes for end users:
 
 * `manifest.target` is now optional, defaulting to an in-memory manifest
 
-improvements for developers:
+notable changes for developers:
 
 * added `resolvePath` utility function

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -24,7 +24,7 @@ Options:
   --serve [HOST:]PORT
     serve generated files via HTTP
   --liveserve [HOST:]PORT
-    serve generated files via HTTP with live reload
+    serve generated files via HTTP with live reloading
 `.trim();
 
 module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {

--- a/lib/util/files/finder.js
+++ b/lib/util/files/finder.js
@@ -6,7 +6,7 @@ let stat = promisify(fs.stat);
 let readDir = promisify(fs.readdir);
 
 module.exports = class FileFinder {
-	constructor(directory, { skipDotfiles, filter = (_ => true) } = {}) {
+	constructor(directory, { skipDotfiles, filter = () => true } = {}) {
 		this.directory = directory;
 		this.filter = filename => {
 			if(skipDotfiles && isDotfile(filename)) {
@@ -33,7 +33,7 @@ function tree(filepath, referenceDir = filepath) {
 	return stat(filepath).
 		then(res => {
 			if(!res.isDirectory()) {
-				return [ path.relative(referenceDir, filepath) ];
+				return [path.relative(referenceDir, filepath)];
 			}
 
 			return readDir(filepath).

--- a/lib/util/resolve.js
+++ b/lib/util/resolve.js
@@ -9,7 +9,7 @@ if(!legacy) { // account for bug in Node v8.9.4 and below
 	let { version } = process;
 	if(version.substr(0, 3) === "v8.") {
 		let [minor, patch] = version.substr(3).split(".").map(i => parseInt(i, 10));
-		legacy = minor < 8 || patch <= 4;
+		legacy = minor <= 9 && patch <= 4;
 	}
 }
 
@@ -31,7 +31,7 @@ function resolveModulePath(filepath, rootDir) {
 	if(legacy) {
 		legacy = process.env.NODE_PATH; // cache previous value
 		rootDir = rootDir.replace(/\/{1,}$/, ""); // strip trailing slashes, to be safe
-		process.env.NODE_PATH = `${rootDir}:${rootDir}/node_modules`;
+		process.env.NODE_PATH = `${rootDir}/node_modules`;
 		require("module").Module._initPaths();
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "faucet-pipeline-core",
-	"version": "1.2.2",
+	"version": "1.3.0",
 	"description": "faucet-pipeline's core library",
 	"author": "FND",
 	"contributors": [
@@ -28,14 +28,14 @@
 		"node": ">=8"
 	},
 	"dependencies": {
-		"browserslist": "~4.6.2",
+		"browserslist": "~4.7.0",
 		"minimist": "~1.2.0",
 		"mkdirp": "~0.5.1",
 		"nite-owl": "~5.0.3"
 	},
 	"devDependencies": {
-		"eslint-config-fnd": "^1.6.0",
-		"mocha": "^6.1.4",
+		"eslint-config-fnd": "^1.8.0",
+		"mocha": "^6.2.0",
 		"npm-run-all": "^4.1.5",
 		"release-util-fnd": "^1.1.1"
 	}

--- a/test/test_manager.js
+++ b/test/test_manager.js
@@ -7,32 +7,45 @@ let assert = require("assert");
 
 let assertSame = assert.strictEqual;
 
+let [major] = process.version.substr(1).split(".").map(i => parseInt(i, 10));
+let MODERN = major >= 12; // legacy doesn't throw due to working directory
+
 describe("asset manager", _ => {
 	let root = path.resolve(__dirname, "fixtures");
 	let cwd;
+	let { exit } = process;
 
 	before(() => {
 		cwd = process.cwd();
 		process.chdir(root);
+		process.exit = code => {
+			throw new Error(`exit ${code}`);
+		};
 	});
 
 	after(() => {
 		process.chdir(cwd);
+		process.exit = exit;
 	});
 
-	it("resolves file paths for local modules and third-party packages", () => {
+	it("resolves file paths for third-party packages", () => {
 		let { resolvePath } = new AssetManager(root);
 
-		let filepath = resolvePath("dummy/src.js");
-		assertSame(path.relative(root, filepath), "dummy/src.js");
-
-		filepath = resolvePath("dummy/pkg.js");
+		let filepath = resolvePath("dummy/pkg.js");
 		assertSame(path.relative(root, filepath), "node_modules/dummy/pkg.js");
 
-		// local modules take precedence over third-party packages
-		["dummy", "dummy/index", "dummy/index.js"].forEach(module => {
-			let filepath = resolvePath(module);
-			assertSame(path.relative(root, filepath), "dummy/index.js");
-		});
+		filepath = resolvePath("./dummy/src.js");
+		assertSame(path.relative(root, filepath), "dummy/src.js");
+
+		if(MODERN) {
+			assert.throws(() => {
+				resolvePath("dummy/src.js");
+			}, /exit 1/);
+
+			["dummy", "dummy/index", "dummy/index.js"].forEach(module => {
+				let filepath = resolvePath(module);
+				assertSame(path.relative(root, filepath), "node_modules/dummy/index.js");
+			});
+		}
 	});
 });


### PR DESCRIPTION
> v1.2.{1,2} will be deprecated
>
> in the process, updated dependencies and revised changelog

* [ ] ensure new path resolution (details in dc5e207b7a245dddc6626d3b5886fe9b265c5637) does not lead to any obvious backwards-compatibility issues (e.g. with faucet-sass - i.e. I hope legacy behavior was never actually being used)
    cf. https://github.com/nodejs/node/issues/29139#issuecomment-523770734
* [x] revise changelog for consistency
* [x] update release date in changelog
* [ ] release v1.3.0
* [ ] deprecate v1.2.x ("re-released as v1.3.0 due to violation of semantic versioning"?)

    ```
    $ npm deprecate faucet-pipeline-core@"~1.2.1" "$msg"
    ```