### PR TITLE
improved server host/port parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@ faucet-pipeline-core version history
 ====================================
 
 
+v1.3.2
+------
+
+_2019-10-27_
+
+notable changes for end users:
+
+* improved host/port handling for `--server` and `--liveserve`
+
+no significant changes for developers
+
+
 v1.3.1
 ------
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,8 +1,13 @@
-let { loadExtension, repr } = require("./util");
+let { loadExtension, abort, repr } = require("./util");
 
-exports.static = function(config, webroot) {
+let DEFAULTS = {
+	host: "localhost",
+	port: 3000
+};
+
+exports.static = (config, webroot) => {
 	let donny = loadExtension("donny", "failed to activate server");
-	let [host, port] = parse(config);
+	let [host, port] = parseHost(config);
 
 	donny({ port, bind: host, webroot }).
 		then(() => {
@@ -10,20 +15,31 @@ exports.static = function(config, webroot) {
 		});
 };
 
-exports.live = function(config, root) {
+exports.live = (config, root) => {
 	let liveServer = loadExtension("live-server", "failed to activate live-server");
-	let [host, port] = parse(config);
+	let [host, port] = parseHost(config);
 
 	liveServer.start({ port, host, root, open: false });
 };
 
-function parse(config) {
-	let i = config.lastIndexOf(":");
-	if(i === -1) { // port only
-		return ["0.0.0.0", config];
-	}
+exports._parseHost = parseHost;
 
-	let host = config.substr(0, i);
-	let port = config.substr(i + 1);
-	return [host, port];
+function parseHost(config) {
+	let { host, port } = DEFAULTS;
+	if(config === true) {
+		return [host, port];
+	}
+	if(!isNaN(config)) { // number or numeric string
+		port = config;
+	} else if(config.substr(0, 1) === ":") { // port only
+		port = config.substr(1);
+	} else {
+		let i = config.lastIndexOf(":");
+		if(i === -1) {
+			abort(`invalid host parameter: ${repr(config, false)} (missing port)`);
+		}
+		host = config.substr(0, i);
+		port = config.substr(i + 1);
+	}
+	return [host, port.substr ? parseInt(port, 10) : port];
 }

--- a/test/test_server.js
+++ b/test/test_server.js
@@ -1,0 +1,43 @@
+/* global describe, before, after, it */
+"use strict";
+
+let { _parseHost } = require("../lib/server");
+let assert = require("assert");
+
+let assertSame = assert.strictEqual;
+
+describe("server host parsing", _ => {
+	let { exit } = process;
+
+	before(() => {
+		process.exit = code => {
+			throw new Error(`exit ${code}`);
+		};
+	});
+
+	after(() => {
+		process.exit = exit;
+	});
+
+	it("determines host/port based on CLI parameter", () => {
+		let [host, port] = _parseHost(true);
+		assertSame(host, "localhost");
+		assertSame(port, 3000);
+
+		[host, port] = _parseHost(8080);
+		assertSame(host, "localhost");
+		assertSame(port, 8080);
+
+		[host, port] = _parseHost(":8080");
+		assertSame(host, "localhost");
+		assertSame(port, 8080);
+
+		[host, port] = _parseHost("localhost:8080");
+		assertSame(host, "localhost");
+		assertSame(port, 8080);
+
+		assert.throws(() => {
+			_parseHost("localhost");
+		}, /exit 1/);
+	});
+});


### PR DESCRIPTION
> turns out 247fa1fcc67bf78394a2e640127d3f0c38d6475b was still flawed, in
> part because it didn't take into account that minimist (CLI parsing)
> might return booleans or numbers (h/t @blynx)

This is an alternative approach to #76, more comprehensive thanks to TDD.