### PR TITLE
simplified custom plugins for end users

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,29 +1,12 @@
 "use strict";
 
 let server = require("./server");
+let { pluginsByBucket } = require("./plugins");
 let AssetManager = require("./manager");
 let resolvePath = require("./util/resolve");
-let { loadExtension, abort, repr } = require("./util");
+let { abort, repr } = require("./util");
 let SerializedRunner = require("./util/runner");
 let browserslist = require("browserslist");
-
-let DEFAULTS = {
-	// maps config identifiers to corresponding import identifiers and buckets
-	plugins: {
-		js: {
-			plugin: "faucet-pipeline-js",
-			bucket: "scripts"
-		},
-		sass: {
-			plugin: "faucet-pipeline-sass",
-			bucket: "styles"
-		},
-		static: {
-			plugin: "faucet-pipeline-static",
-			bucket: "static"
-		}
-	}
-};
 
 module.exports = (referenceDir, config,
 		{ watch, fingerprint, sourcemaps, compact, serve, liveserve }) => {
@@ -34,27 +17,14 @@ module.exports = (referenceDir, config,
 	});
 	let browsers = browserslist.findConfig(referenceDir) || {};
 
-	let plugins = Object.assign({}, DEFAULTS.plugins, config.plugins);
-	let buckets = {
-		static: [],
-		scripts: [],
-		styles: [],
-		markup: []
-	};
-	Object.keys(plugins).forEach(type => {
-		let pluginConfig = config[type];
-		if(!pluginConfig) {
-			return;
-		}
-
-		let { bucket, plugin } = plugins[type];
-		if(!plugin.call) {
-			plugin = loadExtension(plugin, "ERROR: missing plugin");
-		}
-		let build = plugin(pluginConfig, assetManager,
-				{ browsers, sourcemaps, compact });
-		buckets[bucket].push(build);
-	});
+	let plugins = pluginsByBucket(config);
+	// initialize plugins with corresponding configuration
+	let buckets = Object.keys(plugins).reduce((memo, bucket) => {
+		memo[bucket] = plugins[bucket].map(({ plugin, config }) => {
+			return plugin(config, assetManager, { browsers, sourcemaps, compact });
+		});
+		return memo;
+	}, {});
 
 	let runner = new SerializedRunner(files => {
 		return buildStep(buckets.static)(files).

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -54,6 +54,10 @@ function pluginsByBucket(config) {
 // `{ key, bucket, plugin }` object`, with `key` being the configuration key and
 // `plugin` being either a function or a package identifier
 function determinePlugins(plugins = []) {
+	if(!plugins.pop) { // for backwards compatibility
+		plugins = modernize(plugins);
+	}
+
 	let registry = {};
 	// NB: default plugins are resolved lazily because eager loading would
 	//     result in them becoming a hard dependency rather than a convenience
@@ -106,4 +110,18 @@ function loadPlugin(pkg) {
 		plugin = fail("plugin")
 	} = loadExtension(pkg, "ERROR: missing plugin");
 	return { key, bucket, plugin };
+}
+
+// converts legacy `{ key: { bucket, plugin } }` format
+function modernize(plugins) {
+	return Object.entries(plugins).map(([key, _plugin]) => {
+		let { bucket, plugin } = _plugin;
+		if(plugin.substr) {
+			plugin = loadExtension(plugin, "ERROR: missing plugin");
+			if(!plugin.call) { // non-legacy plugin
+				plugin = plugin.plugin;
+			}
+		}
+		return { key, bucket, plugin };
+	});
 }

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -1,0 +1,109 @@
+"use strict";
+
+let { loadExtension, abort, repr } = require("./util");
+
+// common plugins included for convenience
+let DEFAULTS = [{
+	key: "js",
+	bucket: "scripts",
+	plugin: "faucet-pipeline-js"
+}, {
+	key: "sass",
+	bucket: "styles",
+	plugin: "faucet-pipeline-sass"
+}, {
+	key: "static",
+	bucket: "static",
+	plugin: "faucet-pipeline-static"
+}];
+let DEFAULT_KEYS = DEFAULTS.reduce((memo, plugin) => {
+	memo.add(plugin.key);
+	return memo;
+}, new Set());
+let BUCKETS = new Set(["static", "scripts", "styles", "markup"]);
+
+module.exports = {
+	pluginsByBucket,
+	_determinePlugins: determinePlugins
+};
+
+// returns plugin functions grouped by bucket and filtered by relevance (based
+// on configuration)
+function pluginsByBucket(config) {
+	let plugins = determinePlugins(config.plugins);
+	let buckets = [...BUCKETS].reduce((memo, bucket) => {
+		memo[bucket] = [];
+		return memo;
+	}, {});
+	Object.entries(plugins).forEach(([key, _plugin]) => {
+		let pluginConfig = config[key];
+		if(!pluginConfig) {
+			return;
+		}
+
+		let { bucket, plugin } = _plugin;
+		buckets[bucket].push({
+			plugin: plugin.call ? plugin : loadPlugin(plugin).plugin,
+			config: pluginConfig
+		});
+	});
+	return buckets;
+}
+
+// `plugins` is an array of plugins, each either a package identifier or a
+// `{ key, bucket, plugin }` object`, with `key` being the configuration key and
+// `plugin` being either a function or a package identifier
+function determinePlugins(plugins = []) {
+	let registry = {};
+	// NB: default plugins are resolved lazily because eager loading would
+	//     result in them becoming a hard dependency rather than a convenience
+	//     preset - however, that requires us to duplicate the respective
+	//     configuration keys and buckets here
+	DEFAULTS.forEach(plugin => {
+		registerPlugin(registry, plugin, false);
+	});
+	plugins.forEach(plugin => {
+		registerPlugin(registry, plugin, true);
+	});
+	return registry;
+}
+
+function registerPlugin(registry, _plugin, eager) {
+	let { key, bucket, plugin } = resolvePlugin(_plugin, eager);
+	// NB: default plugins may be overridden
+	if(registry[key] && !DEFAULT_KEYS.has(key)) {
+		abort(`ERROR: duplicate plugin key ${repr(key, false)}`);
+	}
+	registry[key] = { bucket, plugin };
+}
+
+function resolvePlugin(_plugin, eager) {
+	if(_plugin.substr) { // package identifier
+		_plugin = loadPlugin(_plugin);
+	}
+
+	let { key, bucket, plugin } = _plugin;
+	if(eager && plugin.substr && (!key || !bucket)) { // auto-configuration
+		let _plugin = loadPlugin(plugin);
+		plugin = _plugin.plugin;
+		// local configuration takes precedence
+		key = key || _plugin.key;
+		bucket = bucket || _plugin.bucket;
+	}
+
+	if(!BUCKETS.has(bucket)) {
+		abort(`ERROR: invalid plugin bucket ${repr(bucket, false)}`);
+	}
+	return { key, bucket, plugin };
+}
+
+function loadPlugin(pkg) {
+	let fail = prop => abort(`ERROR: invalid plugin ${repr(pkg)}; ` +
+			`missing ${repr(prop, false)}`);
+	let {
+		key = fail("key"),
+		bucket = fail("bucket"),
+		plugin = fail("plugin")
+	} = loadExtension(pkg, "ERROR: missing plugin");
+	return { key, bucket, plugin };
+}

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -29,8 +29,8 @@ module.exports = {
 
 // returns plugin functions grouped by bucket and filtered by relevance (based
 // on configuration)
-function pluginsByBucket(config) {
-	let plugins = determinePlugins(config.plugins);
+function pluginsByBucket(config, defaults) {
+	let plugins = determinePlugins(config.plugins, defaults);
 	let buckets = [...BUCKETS].reduce((memo, bucket) => {
 		memo[bucket] = [];
 		return memo;
@@ -42,6 +42,14 @@ function pluginsByBucket(config) {
 		}
 
 		let { bucket, plugin } = _plugin;
+		// special-casing for default plugins' legacy versions
+		if(_plugin.default && plugin.substr) {
+			let __plugin = loadExtension(plugin, "ERROR: missing plugin");
+			if(__plugin.call) { // legacy plugin version
+				plugin = __plugin;
+			}
+		}
+
 		buckets[bucket].push({
 			plugin: plugin.call ? plugin : loadPlugin(plugin).plugin,
 			config: pluginConfig
@@ -53,7 +61,7 @@ function pluginsByBucket(config) {
 // `plugins` is an array of plugins, each either a package identifier or a
 // `{ key, bucket, plugin }` object`, with `key` being the configuration key and
 // `plugin` being either a function or a package identifier
-function determinePlugins(plugins = []) {
+function determinePlugins(plugins = [], defaults = DEFAULTS) {
 	if(!plugins.pop) { // for backwards compatibility
 		plugins = modernize(plugins);
 	}
@@ -63,7 +71,7 @@ function determinePlugins(plugins = []) {
 	//     result in them becoming a hard dependency rather than a convenience
 	//     preset - however, that requires us to duplicate the respective
 	//     configuration keys and buckets here
-	DEFAULTS.forEach(plugin => {
+	defaults.forEach(plugin => {
 		registerPlugin(registry, plugin, false);
 	});
 	plugins.forEach(plugin => {
@@ -78,7 +86,10 @@ function registerPlugin(registry, _plugin, eager) {
 	if(registry[key] && !DEFAULT_KEYS.has(key)) {
 		abort(`ERROR: duplicate plugin key ${repr(key, false)}`);
 	}
-	registry[key] = { bucket, plugin };
+	let entry = registry[key] = { bucket, plugin };
+	if(!eager) {
+		entry.default = true;
+	}
 }
 
 function resolvePlugin(_plugin, eager) {

--- a/test/fixtures/node_modules/faucet-pipeline-dummy/index.js
+++ b/test/fixtures/node_modules/faucet-pipeline-dummy/index.js
@@ -1,0 +1,5 @@
+"use strict";
+
+exports.key = "dummy";
+exports.bucket = "static";
+exports.plugin = function faucetDummy() {};

--- a/test/fixtures/node_modules/faucet-pipeline-invalid-a/index.js
+++ b/test/fixtures/node_modules/faucet-pipeline-invalid-a/index.js
@@ -1,0 +1,4 @@
+"use strict";
+
+exports.key = "dummy";
+exports.plugin = function faucetInvalidA() {};

--- a/test/fixtures/node_modules/faucet-pipeline-invalid-b/index.js
+++ b/test/fixtures/node_modules/faucet-pipeline-invalid-b/index.js
@@ -1,0 +1,4 @@
+"use strict";
+
+exports.bucket = "static";
+exports.plugin = function faucetInvalidB() {};

--- a/test/fixtures/node_modules/faucet-pipeline-invalid-c/index.js
+++ b/test/fixtures/node_modules/faucet-pipeline-invalid-c/index.js
@@ -1,0 +1,4 @@
+"use strict";
+
+exports.key = "dummy";
+exports.bucket = "static";

--- a/test/fixtures/node_modules/faucet-pipeline-js/index.js
+++ b/test/fixtures/node_modules/faucet-pipeline-js/index.js
@@ -1,0 +1,5 @@
+"use strict";
+
+exports.key = "js";
+exports.bucket = "scripts";
+exports.plugin = function faucetJS() {};

--- a/test/fixtures/node_modules/faucet-pipeline-legacy/index.js
+++ b/test/fixtures/node_modules/faucet-pipeline-legacy/index.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = function faucetLegacy() {};

--- a/test/fixtures/node_modules/faucet-pipeline-sass/index.js
+++ b/test/fixtures/node_modules/faucet-pipeline-sass/index.js
@@ -1,0 +1,5 @@
+"use strict";
+
+exports.key = "sass";
+exports.bucket = "scripts";
+exports.plugin = function faucetSass() {};

--- a/test/fixtures/node_modules/faucet-pipeline-static/index.js
+++ b/test/fixtures/node_modules/faucet-pipeline-static/index.js
@@ -1,0 +1,5 @@
+"use strict";
+
+exports.key = "static";
+exports.bucket = "scripts";
+exports.plugin = function faucetStatic() {};

--- a/test/test_plugins.js
+++ b/test/test_plugins.js
@@ -101,7 +101,25 @@ describe("plugin registration", _ => {
 	});
 
 	it("ensures backwards compatibility", () => {
+		let defaults = [{
+			key: "legacy",
+			bucket: "static",
+			plugin: path.resolve(CUSTOM_NODE_PATH, "faucet-pipeline-legacy")
+		}];
 		let res = pluginsByBucket({
+			legacy: [{ foo: "lorem" }]
+		}, defaults);
+		assertDeep(normalizeAll(res), {
+			static: [{
+				plugin: "<Function faucetLegacy>",
+				config: [{ foo: "lorem" }]
+			}],
+			scripts: [],
+			styles: [],
+			markup: []
+		});
+
+		res = pluginsByBucket({
 			dummy: [{ foo: "lorem" }],
 			plugins: {
 				dummy: {
@@ -295,6 +313,8 @@ function normalizeAll(pluginsByBucket) {
 // serializes plugin functions for comparison purposes
 function normalizePlugins(obj) {
 	Object.entries(obj).forEach(([key, plugin]) => {
+		delete plugin.default; // XXX: hacky
+
 		let fn = plugin.plugin;
 		if(fn.call) {
 			plugin.plugin = `<Function ${fn.name}>`;

--- a/test/test_plugins.js
+++ b/test/test_plugins.js
@@ -99,6 +99,46 @@ describe("plugin registration", _ => {
 			markup: []
 		});
 	});
+
+	it("ensures backwards compatibility", () => {
+		let res = pluginsByBucket({
+			dummy: [{ foo: "lorem" }],
+			plugins: {
+				dummy: {
+					bucket: "static",
+					plugin: path.resolve(CUSTOM_NODE_PATH, "faucet-pipeline-dummy")
+				}
+			}
+		});
+		assertDeep(normalizeAll(res), {
+			static: [{
+				plugin: "<Function faucetDummy>",
+				config: [{ foo: "lorem" }]
+			}],
+			scripts: [],
+			styles: [],
+			markup: []
+		});
+
+		res = pluginsByBucket({
+			legacy: [{ bar: "ipsum" }],
+			plugins: {
+				legacy: {
+					bucket: "static",
+					plugin: path.resolve(CUSTOM_NODE_PATH, "faucet-pipeline-legacy")
+				}
+			}
+		});
+		assertDeep(normalizeAll(res), {
+			static: [{
+				plugin: "<Function faucetLegacy>",
+				config: [{ bar: "ipsum" }]
+			}],
+			scripts: [],
+			styles: [],
+			markup: []
+		});
+	});
 });
 
 describe("plugin resolution", _ => {

--- a/test/test_plugins.js
+++ b/test/test_plugins.js
@@ -1,0 +1,269 @@
+/* global describe, before, after, it */
+"use strict";
+
+let { pluginsByBucket, _determinePlugins } = require("../lib/plugins");
+let path = require("path");
+let assert = require("assert");
+
+let { deepStrictEqual: assertDeep } = assert;
+
+let ROOT = path.resolve(__dirname, "fixtures");
+let DEFAULTS = {
+	js: {
+		bucket: "scripts",
+		plugin: "faucet-pipeline-js"
+	},
+	sass: {
+		bucket: "styles",
+		plugin: "faucet-pipeline-sass"
+	},
+	static: {
+		bucket: "static",
+		plugin: "faucet-pipeline-static"
+	}
+};
+
+let { NODE_PATH } = process.env;
+let CUSTOM_NODE_PATH = path.resolve(ROOT, "node_modules");
+
+describe("plugin registration", _ => {
+	before(() => {
+		updateNodePath(NODE_PATH, CUSTOM_NODE_PATH);
+	});
+
+	after(() => {
+		updateNodePath(NODE_PATH);
+	});
+
+	it("only loads default plugins referenced within configuration", () => {
+		let res = pluginsByBucket({
+			js: [{ foo: "lorem" }]
+		});
+		assertDeep(normalizeAll(res), {
+			static: [],
+			scripts: [{
+				plugin: "<Function faucetJS>",
+				config: [{ foo: "lorem" }]
+			}],
+			styles: [],
+			markup: []
+		});
+
+		res = pluginsByBucket({
+			sass: [{ bar: "ipsum" }]
+		});
+		assertDeep(normalizeAll(res), {
+			static: [],
+			scripts: [],
+			styles: [{
+				plugin: "<Function faucetSass>",
+				config: [{ bar: "ipsum" }]
+			}],
+			markup: []
+		});
+
+		res = pluginsByBucket({
+			js: [{ foo: "lorem" }],
+			sass: [{ bar: "ipsum" }]
+		});
+		assertDeep(normalizeAll(res), {
+			static: [],
+			scripts: [{
+				plugin: "<Function faucetJS>",
+				config: [{ foo: "lorem" }]
+			}],
+			styles: [{
+				plugin: "<Function faucetSass>",
+				config: [{ bar: "ipsum" }]
+			}],
+			markup: []
+		});
+	});
+
+	it("allows overriding default plugins", () => {
+		let res = pluginsByBucket({
+			js: [{ foo: "bar" }],
+			plugins: [{
+				key: "js",
+				bucket: "static",
+				plugin: "faucet-pipeline-dummy"
+			}]
+		});
+		assertDeep(normalizeAll(res), {
+			static: [{
+				plugin: "<Function faucetDummy>",
+				config: [{ foo: "bar" }]
+			}],
+			scripts: [],
+			styles: [],
+			markup: []
+		});
+	});
+});
+
+describe("plugin resolution", _ => {
+	let { exit } = process;
+
+	before(() => {
+		process.exit = code => {
+			throw new Error(`exit ${code}`);
+		};
+		updateNodePath(NODE_PATH, CUSTOM_NODE_PATH);
+	});
+
+	after(() => {
+		process.exit = exit;
+		updateNodePath(NODE_PATH);
+	});
+
+	it("provides a default set of plugins", () => {
+		let res = _determinePlugins();
+		assertDeep(normalizePlugins(res), DEFAULTS);
+	});
+
+	it("supports custom plugins", () => {
+		// plugin function within configuration
+		let anon = () => {};
+		let config = [{
+			key: "dummy",
+			bucket: "static",
+			plugin: anon
+		}];
+		let res = _determinePlugins(config);
+		assertDeep(normalizePlugins(res), Object.assign({}, DEFAULTS, {
+			dummy: {
+				bucket: "static",
+				plugin: "<Function anon>"
+			}
+		}));
+
+		// nested package identifier
+		let pkg = "faucet-pipeline-dummy";
+		config[0].plugin = pkg;
+		res = _determinePlugins(config);
+		assertDeep(normalizePlugins(res), Object.assign({}, DEFAULTS, {
+			dummy: {
+				bucket: "static",
+				// NB: plugin not loaded due to comprehensive local configuration
+				plugin: "faucet-pipeline-dummy"
+			}
+		}));
+
+		// simple package identifier
+		res = _determinePlugins([pkg]);
+		assertDeep(normalizePlugins(res), Object.assign({}, DEFAULTS, {
+			dummy: {
+				bucket: "static",
+				plugin: "<Function faucetDummy>"
+			}
+		}));
+	});
+
+	it("allows overriding plugins' default configuration", () => {
+		let config = [{
+			key: "yummy",
+			plugin: "faucet-pipeline-dummy"
+		}];
+		let res = _determinePlugins(config);
+		assertDeep(normalizePlugins(res), Object.assign({}, DEFAULTS, {
+			yummy: {
+				bucket: "static",
+				plugin: "<Function faucetDummy>"
+			}
+		}));
+
+		config[0].bucket = "styles";
+		res = _determinePlugins(config);
+		assertDeep(normalizePlugins(res), Object.assign({}, DEFAULTS, {
+			yummy: {
+				bucket: "styles",
+				// NB: plugin not loaded due to comprehensive local configuration
+				plugin: "faucet-pipeline-dummy"
+			}
+		}));
+	});
+
+	it("balks at invalid package identifiers", () => {
+		assert.throws(() => {
+			_determinePlugins(["faucet-pipeline-yummy"]);
+		}, /exit 1/);
+
+		assert.throws(() => {
+			_determinePlugins([{
+				// NB: local configuration must not be comprehensive to ensure
+				//     plugin is loaded
+				key: "yummy",
+				plugin: "faucet-pipeline-yummy"
+			}]);
+		}, /exit 1/);
+	});
+
+	it("balks at duplicate configuration keys", () => {
+		assert.throws(() => {
+			_determinePlugins([{
+				key: "dummy",
+				bucket: "static",
+				plugin: () => {}
+			}, {
+				key: "dummy",
+				bucket: "styles",
+				plugin: () => {}
+			}]);
+		}, /exit 1/);
+	});
+
+	it("balks at invalid plugins", () => {
+		assert.throws(() => {
+			_determinePlugins(["faucet-pipeline-invalid-a"]);
+		}, /exit 1/);
+
+		assert.throws(() => {
+			_determinePlugins(["faucet-pipeline-invalid-b"]);
+		}, /exit 1/);
+
+		assert.throws(() => {
+			_determinePlugins(["faucet-pipeline-invalid-c"]);
+		}, /exit 1/);
+	});
+
+	it("balks at invalid buckets", () => {
+		let plugin = {
+			key: "dummy",
+			plugin: () => {}
+		};
+		["static", "scripts", "styles", "markup"].forEach(bucket => {
+			plugin.bucket = bucket;
+			assert.doesNotThrow(() => {
+				_determinePlugins([plugin]);
+			}, /exit 1/);
+		});
+
+		plugin.bucket = "dummy";
+		assert.throws(() => {
+			_determinePlugins([plugin]);
+		}, /exit 1/);
+	});
+});
+
+function normalizeAll(pluginsByBucket) {
+	Object.entries(pluginsByBucket).forEach(([bucket, plugins]) => {
+		normalizePlugins(plugins);
+	});
+	return pluginsByBucket;
+}
+
+// serializes plugin functions for comparison purposes
+function normalizePlugins(obj) {
+	Object.entries(obj).forEach(([key, plugin]) => {
+		let fn = plugin.plugin;
+		if(fn.call) {
+			plugin.plugin = `<Function ${fn.name}>`;
+		}
+	});
+	return obj;
+}
+
+function updateNodePath(...paths) {
+	process.env.NODE_PATH = paths.join(":");
+	require("module").Module._initPaths();
+}

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -44,6 +44,7 @@ describe("FileFinder", _ => {
 					"node_modules/faucet-pipeline-invalid-b/index.js",
 					"node_modules/faucet-pipeline-invalid-c/index.js",
 					"node_modules/faucet-pipeline-js/index.js",
+					"node_modules/faucet-pipeline-legacy/index.js",
 					"node_modules/faucet-pipeline-sass/index.js",
 					"node_modules/faucet-pipeline-static/index.js"
 				]);
@@ -66,6 +67,7 @@ describe("FileFinder", _ => {
 					"node_modules/faucet-pipeline-invalid-b/index.js",
 					"node_modules/faucet-pipeline-invalid-c/index.js",
 					"node_modules/faucet-pipeline-js/index.js",
+					"node_modules/faucet-pipeline-legacy/index.js",
 					"node_modules/faucet-pipeline-sass/index.js",
 					"node_modules/faucet-pipeline-static/index.js"
 				]);
@@ -87,6 +89,7 @@ describe("FileFinder", _ => {
 					"node_modules/faucet-pipeline-invalid-b/index.js",
 					"node_modules/faucet-pipeline-invalid-c/index.js",
 					"node_modules/faucet-pipeline-js/index.js",
+					"node_modules/faucet-pipeline-legacy/index.js",
 					"node_modules/faucet-pipeline-sass/index.js",
 					"node_modules/faucet-pipeline-static/index.js"
 				]);

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -38,7 +38,14 @@ describe("FileFinder", _ => {
 					"dummy/index.js",
 					"dummy/src.js",
 					"node_modules/dummy/index.js",
-					"node_modules/dummy/pkg.js"
+					"node_modules/dummy/pkg.js",
+					"node_modules/faucet-pipeline-dummy/index.js",
+					"node_modules/faucet-pipeline-invalid-a/index.js",
+					"node_modules/faucet-pipeline-invalid-b/index.js",
+					"node_modules/faucet-pipeline-invalid-c/index.js",
+					"node_modules/faucet-pipeline-js/index.js",
+					"node_modules/faucet-pipeline-sass/index.js",
+					"node_modules/faucet-pipeline-static/index.js"
 				]);
 			});
 	});
@@ -53,7 +60,14 @@ describe("FileFinder", _ => {
 					"dummy/index.js",
 					"dummy/src.js",
 					"node_modules/dummy/index.js",
-					"node_modules/dummy/pkg.js"
+					"node_modules/dummy/pkg.js",
+					"node_modules/faucet-pipeline-dummy/index.js",
+					"node_modules/faucet-pipeline-invalid-a/index.js",
+					"node_modules/faucet-pipeline-invalid-b/index.js",
+					"node_modules/faucet-pipeline-invalid-c/index.js",
+					"node_modules/faucet-pipeline-js/index.js",
+					"node_modules/faucet-pipeline-sass/index.js",
+					"node_modules/faucet-pipeline-static/index.js"
 				]);
 			});
 	});
@@ -67,7 +81,14 @@ describe("FileFinder", _ => {
 			then(allFiles => {
 				assertDeep(allFiles, [
 					"dummy/index.js",
-					"node_modules/dummy/index.js"
+					"node_modules/dummy/index.js",
+					"node_modules/faucet-pipeline-dummy/index.js",
+					"node_modules/faucet-pipeline-invalid-a/index.js",
+					"node_modules/faucet-pipeline-invalid-b/index.js",
+					"node_modules/faucet-pipeline-invalid-c/index.js",
+					"node_modules/faucet-pipeline-js/index.js",
+					"node_modules/faucet-pipeline-sass/index.js",
+					"node_modules/faucet-pipeline-static/index.js"
 				]);
 			});
 	});
@@ -98,7 +119,7 @@ describe("FileFinder", _ => {
 			});
 	});
 
-	it("matches given files without dotfiles", () => {
+	it("matches given files with custom finder", () => {
 		let fileFinder = new FileFinder(FIXTURES_PATH, {
 			filter: filename => path.basename(filename) === "index.js"
 		});


### PR DESCRIPTION
this fixes #61, allowing users to more easily add custom plugins to their configuration:

```javascript
module.exports = {
    wasm: […],
    plugins: ["faucet-plugin-wasm"]
};
```

or, for power users (e.g. within tests):

```javascript
module.exports = {
    wasn: […],
    plugins: [{
        key: "wasn",
        bucket: "styles",
        plugin: "faucet-plugin-wasm"
    }]
};
```

> by making plugin authors specify configuration key and bucket, we no
> longer have to impose internal implementation details on end users; they
> only have to provide the respective plugin names (package identifiers)
> now, though customization (overriding `key` and `bucket` within local
> configuration) remains possible
>
> NB:
> * this constitutes a breaking change for all plugins
> * some special-casing for default plugins to avoid unwarranted eager
>   loading (cf. inline comment)
> * test coverage is limited to `plugins.js` module; `index.js` remains
>   untested

this proved significantly trickier than expected, but it seems the resulting code is also much easier to grok (though still somewhat convoluted)

we'll need to think about how to communicate this 

* [ ] faucet-js: https://github.com/faucet-pipeline/faucet-pipeline-js/compare/plugin-api
* [ ] faucet-sass
* [ ] faucet-static
* [ ] ?
* [ ] 🤔 use nite-owl's [`reportSet`](https://github.com/faucet-pipeline/nite-owl/commit/8ac37dd41372bd9f959e63a60d2e9c463dc64de2)?
* [ ] ~OT: document How To Write a Plugin - cf. faucet-gorgeon (including details like asset manager and enforcing relative paths as well as subtleties like reporting file status yourself and automatic first run)