### PR TITLE
support for async configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@ faucet-pipeline-core version history
 ====================================
 
 
+v1.5.0
+------
+
+_2020-04-21_
+
+notable changes for end users:
+
+* configuration can now be asynchronous, i.e. `faucet.config.js` may export a
+  promise, allowing for dynamically generated configuration values
+* updated dependencies
+
+no significant changes for developers
+
+
 v1.4.0
 ------
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,8 +8,10 @@ let { abort, repr } = require("./util");
 let SerializedRunner = require("./util/runner");
 let browserslist = require("browserslist");
 
-module.exports = (referenceDir, config,
-		{ watch, fingerprint, sourcemaps, compact, serve, liveserve }) => {
+module.exports = async function faucetDispatch(referenceDir, config,
+		{ watch, fingerprint, sourcemaps, compact, serve, liveserve }) {
+	config = await config;
+
 	let assetManager = new AssetManager(referenceDir, {
 		manifestConfig: config.manifest,
 		fingerprint,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "faucet-pipeline-core",
-	"version": "1.4.0",
+	"version": "1.5.0",
 	"description": "faucet-pipeline's core library",
 	"author": "FND",
 	"contributors": [
@@ -28,13 +28,13 @@
 		"node": ">= 10.12.0"
 	},
 	"dependencies": {
-		"browserslist": "~4.9.1",
+		"browserslist": "~4.12.0",
 		"minimist": "~1.2.5",
 		"nite-owl": "~5.0.4"
 	},
 	"devDependencies": {
 		"eslint-config-fnd": "^1.8.0",
-		"mocha": "^7.1.0",
+		"mocha": "^7.1.1",
 		"npm-run-all": "^4.1.5",
 		"release-util-fnd": "^2.0.0"
 	}


### PR DESCRIPTION
> this is useful for when configuration values aren't available
> statically, e.g. determining `watchDirs` on the fly

please note the remainder of the commit message

my immediate use case is reducing [awkward boilerplate in Gorgeon](https://github.com/FND/gorgeon/blob/b3f0df071c148330fdf969d0ca94541ba7b61ccc/samples/faucet.config.complate.js#L8-L10)

(I'm not sure whether [top-level await](https://github.com/tc39/proposal-top-level-await) would render this obsolete, but it's only at stage 3 right now, so won't be in widespread use for a while)