### PR TITLE
Add support for middlewares in live-server

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,9 +46,9 @@ module.exports = async function faucetDispatch(referenceDir, config,
 		abort("ERROR: serve and liveserve must not be used together");
 	}
 	if(serve) {
-		server.static(serve, assetManager.manifest.webRoot);
+		server.static(serve, assetManager.manifest.webRoot, config.devServer);
 	} else if(liveserve) {
-		server.live(liveserve, assetManager.manifest.webRoot);
+		server.live(liveserve, assetManager.manifest.webRoot, config.devServer);
 	}
 };
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,7 +5,11 @@ let DEFAULTS = {
 	port: 3000
 };
 
-exports.static = (config, webroot) => {
+exports.static = (config, webroot, devServer = {}) => {
+	if(devServer.middlewares) {
+		abort("--static doesn't support middlewares right now, use --liveserve");
+	}
+
 	let donny = loadExtension("donny", "failed to activate server");
 	let [host, port] = parseHost(config);
 
@@ -15,11 +19,12 @@ exports.static = (config, webroot) => {
 		});
 };
 
-exports.live = (config, root) => {
+exports.live = (config, root, devServer = {}) => {
 	let liveServer = loadExtension("live-server", "failed to activate live-server");
 	let [host, port] = parseHost(config);
+	let middleware = devServer.middlewares || [];
 
-	liveServer.start({ port, host, root, open: false });
+	liveServer.start({ port, host, root, middleware, open: false });
 };
 
 exports._parseHost = parseHost;


### PR DESCRIPTION
~I know, this might seem odd, but I will explain. But not now.~

This adds support for Connect middlewares for the dev server. Currently, this is only supported when using `--liveserve` and not `--serve`, because donny doesn't support that right now.

How does it work? You add a `devServer` option to your manifest, and add a middlewares array. It is an array of the actual functions, so if you store them somewhere else, you need to require them. Example for logging every request:

```js
module.exports = {
  manifest: {
    webRoot: "./dist",
  },

  devServer: {
    middlewares: [
      (req, res, next) => {
        // an amazing logger middleware. wow.
        console.log(`${req.method} ${req.url}`);
        next();
      },
    ],
  },
};
```

Use Cases:
* Logging (?)
* Adding HTTP Headers (CORS, CSPs...)
* Doing arbitrary stuff, because you have the full power of Connect