### PR TITLE
resolve non-JavaScript package references via a simplistic heuristic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@ faucet-pipeline-core version history
 ====================================
 
 
+v1.5.1
+------
+
+_?_
+
+notable changes for end users:
+
+* fixes resolution for non-JavaScript package
+
+no significant changes for developers
+
+
 v1.5.0
 ------
 

--- a/lib/util/resolve.js
+++ b/lib/util/resolve.js
@@ -2,6 +2,7 @@
 
 let { abort, repr } = require("./");
 let path = require("path");
+let fs = require("fs");
 
 module.exports = function resolvePath(filepath, referenceDir, { enforceRelative } = {}) {
 	if(/^\.?\.\//.test(filepath)) { // starts with `./` or `../`
@@ -11,8 +12,15 @@ module.exports = function resolvePath(filepath, referenceDir, { enforceRelative 
 	} else { // attempt via Node resolution algorithm
 		try {
 			return require.resolve(filepath, { paths: [referenceDir] });
+		// attempt to resolve non-JavaScript package references via a simplistic heuristic
 		} catch(err) {
-			abort(`ERROR: could not resolve ${repr(filepath)}`);
+			let resolved = path.resolve(referenceDir, "node_modules", filepath);
+			try {
+				fs.statSync(resolved); // ensures file/directory exists
+			} catch(_err) {
+				abort(`ERROR: could not resolve ${repr(filepath)}`);
+			}
+			return resolved;
 		}
 	}
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "faucet-pipeline-core",
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"description": "faucet-pipeline's core library",
 	"author": "FND",
 	"contributors": [

--- a/test/test_manager.js
+++ b/test/test_manager.js
@@ -47,5 +47,8 @@ describe("asset manager", _ => {
 				assertSame(path.relative(root, filepath), "node_modules/dummy/index.js");
 			});
 		}
+
+		filepath = resolvePath("dummy/images");
+		assertSame(path.relative(root, filepath), "node_modules/dummy/images");
 	});
 });

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -37,6 +37,7 @@ describe("FileFinder", _ => {
 					"dummy/.keep",
 					"dummy/index.js",
 					"dummy/src.js",
+					"node_modules/dummy/images/.keep",
 					"node_modules/dummy/index.js",
 					"node_modules/dummy/pkg.js",
 					"node_modules/faucet-pipeline-dummy/index.js",


### PR DESCRIPTION
This is an alternative to the solution proposed in https://github.com/faucet-pipeline/faucet-pipeline-static/pull/37

I think this should be handled by core, so it is solved for other pipelines (like the new image pipeline) as well.