### PR TITLE
faucet-pipeline-images leaves beta stage

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -15,6 +15,10 @@ let DEFAULTS = [{
 	key: "static",
 	bucket: "static",
 	plugin: "faucet-pipeline-static"
+}, {
+	key: "images",
+	bucket: "static",
+	plugin: "faucet-pipeline-images"
 }];
 let DEFAULT_KEYS = DEFAULTS.reduce((memo, plugin) => {
 	memo.add(plugin.key);

--- a/test/test_plugins.js
+++ b/test/test_plugins.js
@@ -20,6 +20,10 @@ let DEFAULTS = {
 	static: {
 		bucket: "static",
 		plugin: "faucet-pipeline-static"
+	},
+	images: {
+		bucket: "static",
+		plugin: "faucet-pipeline-images"
 	}
 };
 


### PR DESCRIPTION
All official pipelines should be loaded automatically. As images is now official, and no longer beta, we need to add it to our plugins list 😄 