### PR TITLE
exposed manifest to independent API consumers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,7 +56,12 @@ exports.faucetDispatch = async function faucetDispatch(referenceDir, config,
 		server.live(liveserve, assetManager.manifest.webRoot);
 	}
 
-	return res; // notifies consumers once the initial build has completed
+	// notify consumers once the initial build has completed
+	return res.then(() => ({
+		get manifest() {
+			return assetManager.manifest.entries;
+		}
+	}));
 };
 
 function buildStep(plugins) {

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -42,14 +42,12 @@ exports.Manifest = class Manifest {
 		this._index.set(key, uri);
 
 		let fp = this.filepath;
-		return fp ? createFile(fp, JSON.stringify(this) + "\n") : Promise.resolve(null);
+		return fp ?
+			createFile(fp, JSON.stringify(this.entries) + "\n") :
+			Promise.resolve(null);
 	}
 
-	toJSON() {
-		let index = this._index;
-		return Array.from(index.keys()).sort().reduce((memo, key) => {
-			memo[key] = index.get(key);
-			return memo;
-		}, {});
+	get entries() {
+		return Object.fromEntries(this._index);
 	}
 };

--- a/lib/util/runner.js
+++ b/lib/util/runner.js
@@ -7,7 +7,7 @@ exports.SerializedRunner = class SerializedRunner {
 
 	run(...args) {
 		if(!this._pending) { // prevent concurrent execution
-			this._pending = augment(this.asyncOp(...args)).
+			this._pending = this.asyncOp(...args).
 				finally(() => {
 					this._pending = null;
 				});
@@ -24,7 +24,7 @@ exports.SerializedRunner = class SerializedRunner {
 		let enqueue = this._pending;
 		let res = this.run(...args);
 		if(enqueue) {
-			this._queued = res = augment(res).
+			this._queued = res = res.
 				finally(() => {
 					this._queued = null;
 				}).
@@ -33,20 +33,3 @@ exports.SerializedRunner = class SerializedRunner {
 		return res;
 	}
 };
-
-function augment(promise) {
-	promise.finally = always;
-	return promise;
-}
-
-// poor man's `Promise#finally` polyfill
-function always(fn) {
-	return this.
-		then(res => {
-			fn();
-			return res;
-		}, err => {
-			fn();
-			throw err;
-		});
-}

--- a/test/test_manifest.js
+++ b/test/test_manifest.js
@@ -5,7 +5,7 @@ let { describe, it, before, after } = require("node:test");
 let path = require("path");
 let assert = require("assert");
 
-let assertSame = assert.strictEqual;
+let assertDeep = assert.deepStrictEqual;
 
 describe("manifest", () => {
 	let root = path.resolve(__dirname, "fixtures");
@@ -24,19 +24,26 @@ describe("manifest", () => {
 		let manifest = new Manifest(root);
 		return manifest.set("foo.png", "foo-abc123.png").
 			then(() => {
-				assertSame(JSON.stringify(manifest), '{"foo.png":"/foo-abc123.png"}');
+				assertDeep(manifest.entries, {
+					"foo.png": "/foo-abc123.png"
+				});
 
 				return manifest.set("bar.css", "bar-def456.css");
 			}).
 			then(() => {
-				assertSame(JSON.stringify(manifest),
-						'{"bar.css":"/bar-def456.css","foo.png":"/foo-abc123.png"}');
+				assertDeep(manifest.entries, {
+					"foo.png": "/foo-abc123.png",
+					"bar.css": "/bar-def456.css"
+				});
 
 				return manifest.set("xox.js", "xox-ghi789.js");
 			}).
 			then(() => {
-				assertSame(JSON.stringify(manifest), // eslint-disable-next-line max-len
-						'{"bar.css":"/bar-def456.css","foo.png":"/foo-abc123.png","xox.js":"/xox-ghi789.js"}');
+				assertDeep(manifest.entries, {
+					"foo.png": "/foo-abc123.png",
+					"bar.css": "/bar-def456.css",
+					"xox.js": "/xox-ghi789.js"
+				});
 			});
 	});
 });


### PR DESCRIPTION
> this saves them the trouble of redundantly reading and deserializing the
> manifest file
>
> this assumes that so far nobody uses
> * ... `faucetDispatch`'s return value, other than waiting for completion
> * ... `Manifest`'s `toJSON` method because that class was never exposed

plus removed a (hopefully) obsolete polyfill